### PR TITLE
Allow configuring the group name

### DIFF
--- a/docker-engine.nuspec
+++ b/docker-engine.nuspec
@@ -6,7 +6,7 @@
   <metadata>
     <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>docker-engine</id>
-    <version>20.10.18</version>
+    <version>20.10.19</version>
     <packageSourceUrl>https://github.com/AJDurant/choco-docker-engine</packageSourceUrl>
     <owners>AJDurant</owners>
     <!-- ============================== -->

--- a/docker-engine.nuspec
+++ b/docker-engine.nuspec
@@ -29,10 +29,22 @@
 
 NOTE: Docker engine for Windows is is simply the service to run containers. You might want to have a look at the "docker-desktop" package for better usability.
 
-This package creates the group `docker-users` and adds the installing user to it. In order to communicate with docker you will need to log out and back in.
+### Package Specific
+This package by default creates the group `docker-users` and adds the installing user to it, you can customise this with package parameters. In order to communicate with docker you will need to log out and back in.
 
 **Please Note**: The docker engine requires the Windows Features: Containers and Microsoft-Hyper-V to be installed in order to function correctly. You can install these with the chocolatey command:
 `choco install Containers Microsoft-Hyper-V --source windowsfeatures`
+
+#### Package Parameters
+The following package parameters can be set:
+
+ * `/DockerGroup:` - Name of the user group for using docker - defaults to "docker-users"
+ * `/noAddGroupUser` - Prevent adding the current user to the DockerGroup
+
+To pass parameters, use `--params "''"` (e.g. `choco install docker-engine [other options] --params="'/DockerGroup:my-docker-group /noAddGroupUser'"`).
+To have choco remember parameters on upgrade, be sure to set `choco feature enable -n=useRememberedArgumentsForUpgrades`.
+
+**Please Note**: If you change the DockerGroup having previously installed docker-engine, the `daemon.json` config file will not be overwritten, you will need to manually update it.
 </description>
     <releaseNotes>https://docs.docker.com/engine/release-notes/</releaseNotes>
     <!-- =============================== -->

--- a/docker-engine.nuspec
+++ b/docker-engine.nuspec
@@ -6,7 +6,7 @@
   <metadata>
     <!-- == PACKAGE SPECIFIC SECTION == -->
     <id>docker-engine</id>
-    <version>20.10.19</version>
+    <version>20.10.20</version>
     <packageSourceUrl>https://github.com/AJDurant/choco-docker-engine</packageSourceUrl>
     <owners>AJDurant</owners>
     <!-- ============================== -->

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -17,7 +17,7 @@ $packageArgs = @{
 
   # You can also use checksum.exe (choco install checksum) and use it
   # e.g. checksum -t sha256 -f path\to\file
-  checksum      = '79B61DC05926BDB591CC0E5CBE5AD8196D29D72A68FC46012C20A905DE1A215C'
+  checksum      = '0DD0B87B99A5424F1501A550ED998523CAA41B71F432B9D71C744E94B3C4315E'
   checksumType  = 'sha256'
 }
 

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -17,7 +17,7 @@ $packageArgs = @{
 
   # You can also use checksum.exe (choco install checksum) and use it
   # e.g. checksum -t sha256 -f path\to\file
-  checksum      = '0DD0B87B99A5424F1501A550ED998523CAA41B71F432B9D71C744E94B3C4315E'
+  checksum      = '11A7D4E19DFD182921CB528CF9722F30E204AC140FCAD298B18F5E2D63CD37FF'
   checksumType  = 'sha256'
 }
 


### PR DESCRIPTION
Fixes #4

You can now specify `/DockerGroup` as a package parameter to customise the group name.

You can also use the boolean flag `/noAddGroupUser` to prevent adding the current user to the docker group.